### PR TITLE
Tweak README with editing and flashing specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ V2 PCBs were only used in the 3rd GB round (R3). To confirm which version you ne
     - Change [the conf file](/config/corneish_zen.conf) to edit configuration settings like changing the deep sleep timeout
 4. Commit and push your changes to your personal repo. Upon pushing it, GitHub Actions will start building a new version of your firmware with the updated keymap.
 
+> **Note**
+> 
+> After forking, you can also edit the files directly in the GitHub web interface using the edit button on the top right (with keyboard shortcut `e`) or [GitHub Dev](https://github.com/github/dev) (with keyboard shortcut `.`) and commit your changes.
+
 ## Firmware Files
 
 To locate your firmware files...
@@ -34,8 +38,8 @@ To locate your firmware files...
 3. Select the desired workflow run in the centre area of the page (based on date and time of the build you wish to use). You can also start a new build from this page by clicking the "Run workflow" button.
 4. After clicking the desired workflow run, you should be presented with a section at the bottom of the page called "Artifacts". This section contains the results of your build, in a file called "firmware.zip"
 5. Download the firmware zip archive and extract the two `.uf2` files. They are named according to which side they need to be flashed to.
-6. Flash the firmware to your keyboard by double-clicking the reset button to put the it in bootloader mode. A window should pop up showing the contents of the storage on the keyboard. Drag and drop the correct .uf2 file into the window. When the upload is complete the window will close and the keyboard will exit bootloader mode.
-    - If you only changed [the keymap file](/config/corneish_zen.keymap) you only need to flash the left side firmware to the left half.
-    - If you changed [the conf file](/config/corneish_zen.conf) you should flash both halves their respective files.
+6. Flash the firmware to your keyboard by double-clicking the reset button to put the it in bootloader mode. A window should pop up showing the contents of the storage on the keyboard. Drag and drop the correct `.uf2` file into the window. When the upload is complete the window will close and the keyboard will exit bootloader mode.
+    - If you only changed [the keymap file](/config/corneish_zen.keymap) you only need to flash the left side firmware to the left side.
+    - If you changed [the conf file](/config/corneish_zen.conf) you should flash both sides their respective files.
 
 Your keyboard is now ready to use.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ V2 PCBs were only used in the 3rd GB round (R3). To confirm which version you ne
 
 > **Note**
 > 
-> After forking, you can also edit the files directly in the GitHub web interface using the edit button on the top right (with keyboard shortcut `e`) or [GitHub Dev](https://github.com/github/dev) (with keyboard shortcut `.`) and commit your changes.
+> After forking the repo to your own account, you can also edit the files directly using the GitHub web interface via the edit button on the top right (keyboard shortcut `e`) or via the [GitHub Dev](https://github.com/github/dev) interface (keyboard shortcut `.`) and commit your changes.
 
 ## Firmware Files
 

--- a/README.md
+++ b/README.md
@@ -14,24 +14,28 @@ V2 PCBs were only used in the 3rd GB round (R3). To confirm which version you ne
 
 - The [official ZMK Firmware GitHub](https://github.com/zmkfirmware/zmk) repository. View the keymaps for other boards and shields as a starting point for your keymap.
 - The [official ZMK Documentation](https://zmk.dev/docs) web site. Find the answers to many of your questions about ZMK Firmware.
-- The [official ZMK Discord Server](https://discord.gg/8cfMkQksSB). Instant conversations with other ZMK developers and users. Great technical resource!
+- The [official ZMK Discord Server](https://zmk.dev/community/discord/invite). Instant conversations with other ZMK developers and users. Great technical resource!
 
 ## Instructions
 
 1. Log into, or sign up for, your personal GitHub account.
 2. Fork this repository to your local computer, and then push it to your GitHub personal account. ([instructions](https://docs.github.com/en/get-started/quickstart/fork-a-repo))
-3. Edit the keymap file(s) to suit your needs
+3. Edit the keymap file(s) to suit your needs:
+    - Change [the keymap file](/config/corneish_zen.keymap) to edit keycodes, add new layers etc.
+    - Change [the conf file](/config/corneish_zen.conf) to edit configuration settings like changing the deep sleep timeout
 4. Commit and push your changes to your personal repo. Upon pushing it, GitHub Actions will start building a new version of your firmware with the updated keymap.
 
 ## Firmware Files
 
 To locate your firmware files...
 
-1. log into GitHub and navigate to your personal config repository you just uploaded your keymap changes to.
+1. Log into GitHub and navigate to your personal config repository you just uploaded your keymap changes to.
 2. Click "Actions" in the main navigation, and in the left navigation click the "Build" link.
 3. Select the desired workflow run in the centre area of the page (based on date and time of the build you wish to use). You can also start a new build from this page by clicking the "Run workflow" button.
 4. After clicking the desired workflow run, you should be presented with a section at the bottom of the page called "Artifacts". This section contains the results of your build, in a file called "firmware.zip"
-5. Download the firmware zip archive and extract the two .uf2 files. They are named according to which side they need to be flashed to.
+5. Download the firmware zip archive and extract the two `.uf2` files. They are named according to which side they need to be flashed to.
 6. Flash the firmware to your keyboard by double-clicking the reset button to put the it in bootloader mode. A window should pop up showing the contents of the storage on the keyboard. Drag and drop the correct .uf2 file into the window. When the upload is complete the window will close and the keyboard will exit bootloader mode.
+    - If you only changed [the keymap file](/config/corneish_zen.keymap) you only need to flash the left side firmware to the left half.
+    - If you changed [the conf file](/config/corneish_zen.conf) you should flash both halves their respective files.
 
 Your keyboard is now ready to use.


### PR DESCRIPTION
A few changes to improve the README for new users:
- Replace ZMK Discord invite with the special URL
- Specify what files exactly to edit
- Add note on editing files without cloning repo locally
- Add note on when each side firmware needs to be flashed