### PR TITLE
Fix board names for ZMK Hardware Model v2 (with //zmk variant)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 include:
-  - board: corneish_zen_v2_left
+  - board: corneish_zen_left//zmk
     # snippet: zmk-usb-logging  # uncomment to enable logging
-  - board: corneish_zen_v2_right
-  - board: corneish_zen_v2_left
+  - board: corneish_zen_right//zmk
+  - board: corneish_zen_left//zmk
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: corneish_zen_v2_left_with_studio
-  # - board: corneish_zen_v1_left
-  # - board: corneish_zen_v1_right
+  # - board: corneish_zen_left@1.0.0//zmk
+  # - board: corneish_zen_right@1.0.0//zmk


### PR DESCRIPTION
ZMK migrated to Hardware Model v2 (HWMv2), which changed how boards are
named. The old `corneish_zen_v2_left` / `corneish_zen_v2_right` identifiers
no longer exist in ZMK main, causing all builds to fail with:

  No board named 'corneish_zen_v2_left' found.

This is similar to #38 but includes the `//zmk` variant suffix, which is
required by the HWMv2 spec. The canonical board identifiers are defined in
`corneish_zen.zmk.yml` in the ZMK repo itself as `corneish_zen_left//zmk`
and `corneish_zen_right//zmk`. Without the suffix, the build system receives
an ambiguous target and may not resolve to the correct variant.

This fix has been tested and produces a successful build with all three
firmware artifacts.