### PR TITLE
Pin the ZMK repo to v0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,4 +3,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3 # this should match the revision in the west.yml

--- a/config/west.yml
+++ b/config/west.yml
@@ -5,7 +5,8 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3
+      # revision: main # To use the latest (frequently breaking) changes. Must also edit the .github/workflows/build.yml to match
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
Currently, the build is failing.

This PR contains a recommended change that will get the actions back in a working state, as main has the latest changes, and thus, contains the breaking changes. Now that ZMK uses versions, we can keep the actions in a stable working state.

When the bug with split boards is resolved in v0.4, we can pin to that version instead, but until we decide to make such a change, this fix will keep the repo actions in a working state.

https://zmk.dev/blog/2025/06/20/pinned-zmk